### PR TITLE
Add initial support for signature help

### DIFF
--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -19,6 +19,7 @@ import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.SignatureHelpOptions;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -26,6 +27,7 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -47,8 +49,10 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
 
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         final InitializeResult res = new InitializeResult(new ServerCapabilities());
+        final SignatureHelpOptions signatureHelpOptions = new SignatureHelpOptions(Collections.singletonList("("));
         res.getCapabilities().setCompletionProvider(new CompletionOptions());
         res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
+        res.getCapabilities().setSignatureHelpProvider(signatureHelpOptions);
 
         return CompletableFuture.supplyAsync(() -> res);
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.signature;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureInformation;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.SymbolEnter;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.SymbolResolver;
+import org.wso2.ballerinalang.compiler.semantics.model.Scope;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.Name;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Utility functions for the signature help.
+ */
+public class SignatureHelpUtil {
+
+    /**
+     * Get the name of the callable item. This ideally should be a ballerina function.
+     *
+     * @param position          Position of the signature help triggered
+     * @param fileContent       File content to search callable item name
+     * @return {@link String}   Callable Item name
+     */
+    public static String getCallableItemName(Position position, String fileContent) {
+        int lineNumber = position.getLine();
+        int character = position.getCharacter();
+        // Here add offset of 2 since the indexing is zero based
+        String[] lineTokens = fileContent.split("\\r?\\n", lineNumber + 2);
+        String line = lineTokens[lineNumber];
+        int counter = character - 2;
+        String callableItemName = "";
+        while (true) {
+            if (counter < 0) {
+                return callableItemName;
+            }
+            char c = line.charAt(counter);
+            if (!(Character.isLetterOrDigit(c) || ("" + c).equals("_"))) {
+                callableItemName = line.substring(counter + 1, character - 1);
+                break;
+            }
+            counter--;
+        }
+        return callableItemName;
+    }
+
+    /**
+     * Get the functionSignatureHelp instance.
+     *
+     * @param functionName              name of the function
+     * @param pkg                       BLang Package
+     * @param compilerContext           compiler context instance
+     * @return {@link SignatureHelp}    Signature help for the completion
+     */
+    public static SignatureHelp getFunctionSignatureHelp(String functionName, BLangPackage pkg,
+                                                         CompilerContext compilerContext) {
+        SymbolResolver symbolResolver = SymbolResolver.getInstance(compilerContext);
+        SymbolEnv pkgEnv = SymbolEnter.getInstance(compilerContext).packageEnvs.get(pkg.symbol);
+        List<List<SignatureParamInfo>> paramLists = new ArrayList<>();
+
+        Map<Name, Scope.ScopeEntry> visibleSymbols = symbolResolver.getAllVisibleInScopeSymbols(pkgEnv);
+        // Scan through the visible packages
+        List<Scope.ScopeEntry> bInvokableSymbols = visibleSymbols.entrySet()
+                .stream()
+                .filter(mapEntry -> mapEntry.getValue().symbol instanceof BInvokableSymbol
+                        && mapEntry.getValue().symbol.getName().getValue().equals(functionName))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+
+        bInvokableSymbols.forEach(bInvokableSymbol -> {
+            List<SignatureParamInfo> paramList = new ArrayList<>();
+            ((BInvokableSymbol) bInvokableSymbol.symbol).getParameters().forEach(bVarSymbol -> {
+                SignatureParamInfo signatureParamInfo = new SignatureParamInfo();
+                signatureParamInfo.setParamType(bVarSymbol.getType().toString());
+                signatureParamInfo.setParamValue(bVarSymbol.getName().getValue());
+                paramList.add(signatureParamInfo);
+            });
+            paramLists.add(paramList);
+        });
+
+        SignatureHelp signatureHelp = new SignatureHelp();
+        signatureHelp.setSignatures(getSignatureInformations(paramLists, functionName));
+        signatureHelp.setActiveParameter(0);
+        signatureHelp.setActiveSignature(0);
+
+        return signatureHelp;
+    }
+
+    private static List<SignatureInformation> getSignatureInformations(List<List<SignatureParamInfo>> paramInfoList,
+                                                                      String funcName) {
+
+        List<SignatureInformation> signatureInformationList = new ArrayList<>();
+        paramInfoList.forEach(paramsList -> {
+            String signature = funcName + "(" +
+                    paramsList.stream()
+                            .map(SignatureParamInfo::toString)
+                            .collect(Collectors.joining(", ")) +
+                    ")";
+            SignatureInformation signatureInformation = new SignatureInformation();
+            signatureInformation.setLabel(signature);
+            signatureInformationList.add(signatureInformation);
+        });
+        return signatureInformationList;
+    }
+
+    private static class SignatureParamInfo {
+        private String paramValue;
+
+        private String paramType;
+
+        void setParamValue(String paramValue) {
+            this.paramValue = paramValue;
+        }
+
+        void setParamType(String paramType) {
+            this.paramType = paramType;
+        }
+
+        @Override
+        public String toString() {
+            return this.paramType + " " + this.paramValue;
+        }
+    }
+}

--- a/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpUtilTest.java
+++ b/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.signature;
+
+import org.eclipse.lsp4j.Position;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ * Test Case to verify the Signature help utility functions
+ */
+public class SignatureHelpUtilTest {
+    private static final ClassLoader CLASS_LOADER = SignatureHelpUtilTest.class.getClassLoader();
+    @Test(description = "Test get callable unit name")
+    public void getCallableItemNameTest() throws URISyntaxException, IOException {
+        URI fileLocation = CLASS_LOADER.getResource("signature" + File.separator + "util"
+                + File.separator + "testUtil.bal").toURI();
+        String stringContent = new String(Files.readAllBytes(Paths.get(fileLocation)));
+        Position position = new Position(1, 31);
+        Assert.assertEquals("test_function_name", SignatureHelpUtil.getCallableItemName(position, stringContent));
+    }
+}

--- a/modules/langserver-core/src/test/resources/signature/util/testUtil.bal
+++ b/modules/langserver-core/src/test/resources/signature/util/testUtil.bal
@@ -1,0 +1,3 @@
+function testUtilFunction() {
+    testPkg.test_function_name()
+}


### PR DESCRIPTION
## Purpose
> Need to provide the user, a way to identify the description of the function signature

## Goals
> With the signature help option of language server protocol, we enable the ability to provide the signature information to user

## Approach
> 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1329674/33522666-b97286ce-d817-11e7-8cca-5e287fe56126.gif)