### PR TITLE
Resolve Task #45 - Introduce Operation context

### DIFF
--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -53,6 +53,7 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
         res.getCapabilities().setCompletionProvider(new CompletionOptions());
         res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
         res.getCapabilities().setSignatureHelpProvider(signatureHelpOptions);
+        res.getCapabilities().setDefinitionProvider(true);
 
         return CompletableFuture.supplyAsync(() -> res);
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
@@ -1,0 +1,53 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.langserver;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.Vocabulary;
+import org.ballerinalang.langserver.completions.PossibleToken;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.List;
+
+/**
+ * Text Document Service context keys for the completion operation context
+ * @since 0.95.5
+ */
+public class DocumentServiceKeys {
+    public static final LanguageServerContext.Key<TextDocumentPositionParams> POSITION_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<String> FILE_NAME_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<CompilerContext> COMPILER_CONTEXT_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<ParserRuleContext> PARSER_RULE_CONTEXT_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<List<PossibleToken>> POSSIBLE_TOKENS_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<TokenStream> TOKEN_STREAM_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<Vocabulary> VOCABULARY_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<Integer> TOKEN_INDEX_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<SymbolTable> SYMBOL_TABLE_KEY
+            = new LanguageServerContext.Key<>();
+}

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LanguageServerContext.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LanguageServerContext.java
@@ -15,21 +15,34 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
-
-package org.ballerinalang.langserver.completions.resolvers.parsercontext;
-
-import org.ballerinalang.langserver.TextDocumentServiceContext;
-import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
-import org.eclipse.lsp4j.CompletionItem;
-
-import java.util.ArrayList;
+package org.ballerinalang.langserver;
 
 /**
- * Parser rule based Item resolver for the Worker reply statement.
+ * Ballerina Language server context.
+ * @since 0.95.5
  */
-public class ParserRuleWorkerReplyContext extends AbstractItemResolver {
-    @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
-        return new ArrayList<>();
+public interface LanguageServerContext {
+
+    /**
+     * Add new Context property.
+     * @param key   Property Key
+     * @param value Property value
+     * @param <V>   Key Type
+     */
+    <V> void put(Key<V> key, V value);
+
+    /**
+     * Get property by Key.
+     * @param key   Property Key
+     * @param <V>   Key Type
+     * @return {@link Object}   Property
+     */
+    <V> V get(Key<V> key);
+
+    /**
+     * @param <K>
+     * @since 0.95.5
+     */
+    class Key<K> {
     }
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceContext.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceContext.java
@@ -15,21 +15,27 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
+package org.ballerinalang.langserver;
 
-package org.ballerinalang.langserver.completions.resolvers.parsercontext;
-
-import org.ballerinalang.langserver.TextDocumentServiceContext;
-import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
-import org.eclipse.lsp4j.CompletionItem;
-
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * Parser rule based Item resolver for the Worker reply statement.
+ * Language server context for text document server.
+ * @since 0.95.5
  */
-public class ParserRuleWorkerReplyContext extends AbstractItemResolver {
+public class TextDocumentServiceContext implements LanguageServerContext {
+
+    private Map<Key<?>, Object> props = new HashMap<>();
+
     @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
-        return new ArrayList<>();
+    public <V> void put(Key<V> key, V value) {
+        props.put(key, value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <V> V get(Key<V> key) {
+        return (V) props.get(key);
     }
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionKeys.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionKeys.java
@@ -15,21 +15,20 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
+package org.ballerinalang.langserver.completions;
 
-package org.ballerinalang.langserver.completions.resolvers.parsercontext;
+import org.ballerinalang.langserver.LanguageServerContext;
+import org.wso2.ballerinalang.compiler.tree.BLangNode;
 
-import org.ballerinalang.langserver.TextDocumentServiceContext;
-import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
-import org.eclipse.lsp4j.CompletionItem;
-
-import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Parser rule based Item resolver for the Worker reply statement.
+ * Text Document Service context keys for the completion operation context
+ * @since 0.95.5
  */
-public class ParserRuleWorkerReplyContext extends AbstractItemResolver {
-    @Override
-    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
-        return new ArrayList<>();
-    }
+public class CompletionKeys {
+    public static final LanguageServerContext.Key<BLangNode> SYMBOL_ENV_NODE_KEY
+            = new LanguageServerContext.Key<>();
+    public static final LanguageServerContext.Key<List<SymbolInfo>> VISIBLE_SYMBOLS_KEY
+            = new LanguageServerContext.Key<>();
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CursorScopeResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CursorScopeResolver.java
@@ -1,0 +1,57 @@
+package org.ballerinalang.langserver.completions;
+
+import org.ballerinalang.langserver.completions.util.positioning.resolvers.BlockStatementScopeResolver;
+import org.ballerinalang.langserver.completions.util.positioning.resolvers.CursorPositionResolver;
+import org.ballerinalang.langserver.completions.util.positioning.resolvers.PackageNodeScopeResolver;
+import org.ballerinalang.langserver.completions.util.positioning.resolvers.ResourceParamScopeResolver;
+import org.ballerinalang.langserver.completions.util.positioning.resolvers.ServiceScopeResolver;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Enum for the cursor scope resolvers.
+ */
+enum CursorScopeResolver {
+
+    BLOCK_STMT_SCOPE(BlockStatementScopeResolver.class, new BlockStatementScopeResolver()),
+    RESOURCE_PARAM_SCOPE(ResourceParamScopeResolver.class, new ResourceParamScopeResolver()),
+    PACKAGE_NODE_SCOPE(PackageNodeScopeResolver.class, new PackageNodeScopeResolver()),
+    service_SCOPE(ServiceScopeResolver.class, new ServiceScopeResolver());
+
+    private final Class context;
+    private final CursorPositionResolver cursorPositionResolver;
+    private static final Map<Class, CursorPositionResolver> resolverMap =
+            Collections.unmodifiableMap(initializeMapping());
+
+    CursorScopeResolver(Class context, CursorPositionResolver positionResolver) {
+        this.context = context;
+        this.cursorPositionResolver = positionResolver;
+    }
+
+    private Class getContext() {
+        return context;
+    }
+
+    private CursorPositionResolver getCompletionItemResolver() {
+        return cursorPositionResolver;
+    }
+
+    /**
+     * Get the resolver by the class.
+     * @param context - context class to extract the relevant resolver
+     * @return {@link CursorPositionResolver} - Item resolver for the given context
+     */
+    public static CursorPositionResolver getResolverByClass(Class context) {
+        return resolverMap.get(context);
+    }
+
+    private static Map<Class, CursorPositionResolver> initializeMapping() {
+        Map<Class, CursorPositionResolver> map = new HashMap<>();
+        for (CursorScopeResolver resolver : CursorScopeResolver.values()) {
+            map.put(resolver.getContext(), resolver.getCompletionItemResolver());
+        }
+        return map;
+    }
+}

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.ArrayList;
  */
 public class AnnotationAttachmentContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         return new ArrayList<>();
     }
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/AnnotationAttachmentResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
@@ -29,16 +29,16 @@ import java.util.List;
  */
 public class AnnotationAttachmentResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
-        return filterAnnotations(dataModel);
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
+        return filterAnnotations(completionContext);
     }
 
     /**
      * Filter the annotations from the data model.
-     * @param dataModel - Suggestions filter Data model
+     * @param completionContext - Completion operation context
      * @return {@link List}
      */
-    ArrayList<CompletionItem> filterAnnotations(SuggestionsFilterDataModel dataModel) {
+    ArrayList<CompletionItem> filterAnnotations(TextDocumentServiceContext completionContext) {
 
 //        Set<Map.Entry<String, ModelPackage>> packages = dataModel.getPackages();
 //        if (packages == null) {

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangStructContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BLangStructContextResolver.java
@@ -18,7 +18,9 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.eclipse.lsp4j.CompletionItem;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
@@ -32,14 +34,14 @@ import java.util.stream.Collectors;
  */
 public class BLangStructContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
-        List filteredTypes = dataModel.getVisibleSymbols().stream()
+        List filteredTypes = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY).stream()
                 .filter(symbolInfo -> symbolInfo.getScopeEntry().symbol instanceof BTypeSymbol)
                 .collect(Collectors.toList());
         filteredTypes.forEach(symbolInfo ->
                 completionItems.add(this.populateBTypeCompletionItem((SymbolInfo) symbolInfo)));
-        this.populateBasicTypes(completionItems, dataModel.getSymbolTable());
+        this.populateBasicTypes(completionItems, completionContext.get(DocumentServiceKeys.SYMBOL_TABLE_KEY));
         return completionItems;
     }
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BlockStatementContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/BlockStatementContextResolver.java
@@ -18,7 +18,9 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
@@ -35,13 +37,14 @@ import java.util.HashMap;
  */
 public class BlockStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         AbstractItemResolver itemResolver;
 
-        if (dataModel.getParserRuleContext() != null) {
-            itemResolver = CompletionItemResolver.getResolverByClass(dataModel.getParserRuleContext().getClass());
-            completionItems.addAll(itemResolver.resolveItems(dataModel));
+        ParserRuleContext parserRuleContext = completionContext.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);
+        if (parserRuleContext != null) {
+            itemResolver = CompletionItemResolver.getResolverByClass(parserRuleContext.getClass());
+            completionItems.addAll(itemResolver.resolveItems(completionContext));
         } else {
             CompletionItem workerItem = new CompletionItem();
             workerItem.setLabel(ItemResolverConstants.WORKER);
@@ -53,7 +56,7 @@ public class BlockStatementContextResolver extends AbstractItemResolver {
             completionItems.add(workerItem);
 
             itemResolver = CompletionItemResolver.getResolverByClass(StatementContextResolver.class);
-            completionItems.addAll(itemResolver.resolveItems(dataModel));
+            completionItems.addAll(itemResolver.resolveItems(completionContext));
 
             // Add the var keyword
             CompletionItem varKeyword = new CompletionItem();

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorActionContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorActionContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.ballerinalang.model.AnnotationAttachment;
 import org.eclipse.lsp4j.CompletionItem;
@@ -29,16 +29,16 @@ import java.util.ArrayList;
  */
 public class ConnectorActionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
-        if (this.isAnnotationContext(dataModel)) {
+        if (this.isAnnotationContext(completionContext)) {
             completionItems.addAll(
-                    CompletionItemResolver.getResolverByClass(AnnotationAttachment.class).resolveItems(dataModel)
+                    CompletionItemResolver
+                            .getResolverByClass(AnnotationAttachment.class).resolveItems(completionContext)
             );
         }
-
         return completionItems;
     }
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorDefinitionContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ConnectorDefinitionContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
 import org.ballerinalang.langserver.completions.consts.Snippet;
@@ -32,11 +32,11 @@ import java.util.ArrayList;
  */
 public class ConnectorDefinitionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
-        if (!this.isAnnotationContext(dataModel)) {
+        if (!this.isAnnotationContext(completionContext)) {
             CompletionItem connectorActionItem = new CompletionItem();
             connectorActionItem.setLabel(ItemResolverConstants.ACTION);
             connectorActionItem.setInsertText(Snippet.CONNECTOR_ACTION.toString());

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/DefaultResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/DefaultResolver.java
@@ -15,10 +15,10 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
-
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
 import org.ballerinalang.langserver.completions.consts.Snippet;
@@ -33,7 +33,8 @@ import java.util.ArrayList;
  */
 public class DefaultResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    @SuppressWarnings("unchecked")
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         CompletionItem workerItem = new CompletionItem();
@@ -44,11 +45,11 @@ public class DefaultResolver extends AbstractItemResolver {
         workerItem.setSortText(Priority.PRIORITY7.name());
         completionItems.add(workerItem);
 
-        populateCompletionItemList(dataModel.getVisibleSymbols(), completionItems);
+        populateCompletionItemList(completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY), completionItems);
 
         // Add the statement templates
         StatementTemplateFilter statementTemplateFilter = new StatementTemplateFilter();
-        completionItems.addAll(statementTemplateFilter.filterItems(dataModel));
+        completionItems.addAll(statementTemplateFilter.filterItems(completionContext));
 
         return completionItems;
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/GlobalScopeResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/GlobalScopeResolver.java
@@ -19,7 +19,9 @@
 package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
@@ -34,22 +36,23 @@ import java.util.stream.Collectors;
 public class GlobalScopeResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
 
-        ParserRuleContext parserRuleContext = dataModel.getParserRuleContext();
+        ParserRuleContext parserRuleContext = completionContext.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);
 
         if (parserRuleContext == null) {
             // If the parser rule context is null we don't have any errors. In this case we add the types
-            List<SymbolInfo> bTypeSymbolInfo = dataModel.getVisibleSymbols()
+            List<SymbolInfo> bTypeSymbolInfo = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY)
                     .stream()
                     .filter(symbolInfo -> symbolInfo.getScopeEntry().symbol.type != null)
                     .collect(Collectors.toList());
             this.populateCompletionItemList(bTypeSymbolInfo, completionItems);
         } else {
-            return CompletionItemResolver.getResolverByClass(parserRuleContext.getClass()).resolveItems(dataModel);
+            return CompletionItemResolver
+                    .getResolverByClass(parserRuleContext.getClass()).resolveItems(completionContext);
         }
 
         return completionItems;

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageActionsAndFunctionsResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageActionsAndFunctionsResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
@@ -27,7 +27,7 @@ import java.util.ArrayList;
  */
 public class PackageActionsAndFunctionsResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
 //        List<SymbolInfo> searchList = filterPackageActionsAndFunctions(dataModel, symbols);

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageNameContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/PackageNameContextResolver.java
@@ -19,7 +19,8 @@
 package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.TokenStream;
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -31,11 +32,11 @@ import java.util.ArrayList;
  */
 public class PackageNameContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
-        TokenStream tokenStream = dataModel.getTokenStream();
-        int currentTokenIndex = dataModel.getTokenIndex();
+        TokenStream tokenStream = completionContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
+        int currentTokenIndex = completionContext.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
         int tokenIterator = currentTokenIndex - 1;
         boolean proceed = true;
 

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ParameterContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ParameterContextResolver.java
@@ -18,7 +18,9 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.eclipse.lsp4j.CompletionItem;
@@ -33,9 +35,9 @@ import java.util.stream.Collectors;
  */
 public class ParameterContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
-        List<SymbolInfo> filteredSymbols = dataModel.getVisibleSymbols()
+        List<SymbolInfo> filteredSymbols = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY)
                 .stream()
                 .filter(symbolInfo -> symbolInfo.getScopeEntry().symbol instanceof BTypeSymbol)
                 .collect(Collectors.toList());
@@ -48,7 +50,7 @@ public class ParameterContextResolver extends AbstractItemResolver {
             completionItems.add(completionItem);
         });
 
-        this.populateBasicTypes(completionItems, dataModel.getSymbolTable());
+        this.populateBasicTypes(completionItems, completionContext.get(DocumentServiceKeys.SYMBOL_TABLE_KEY));
 
         return completionItems;
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ResourceContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ResourceContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.ballerinalang.model.AnnotationAttachment;
 import org.eclipse.lsp4j.CompletionItem;
@@ -31,13 +31,14 @@ import java.util.ArrayList;
 public class ResourceContextResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
-        if (this.isAnnotationContext(dataModel)) {
+        if (this.isAnnotationContext(completionContext)) {
             completionItems.addAll(
-                    CompletionItemResolver.getResolverByClass(AnnotationAttachment.class).resolveItems(dataModel)
+                    CompletionItemResolver
+                            .getResolverByClass(AnnotationAttachment.class).resolveItems(completionContext)
             );
         }
 

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ServiceContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/ServiceContextResolver.java
@@ -17,7 +17,8 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
@@ -36,11 +37,11 @@ import java.util.stream.Collectors;
 public class ServiceContextResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         // TODO: Add annotations
         this.addResourceCompletionItem(completionItems);
-        this.addTypes(completionItems, dataModel.getVisibleSymbols());
+        this.addTypes(completionItems, completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY));
         return completionItems;
     }
 

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/StatementContextResolver.java
@@ -17,7 +17,8 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.util.filters.StatementTemplateFilter;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -28,13 +29,14 @@ import java.util.ArrayList;
  */
 public class StatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    @SuppressWarnings("unchecked")
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         StatementTemplateFilter statementTemplateFilter = new StatementTemplateFilter();
-//        // Add the statement templates
-        completionItems.addAll(statementTemplateFilter.filterItems(dataModel));
-        populateCompletionItemList(dataModel.getVisibleSymbols(), completionItems);
+        // Add the statement templates
+        completionItems.addAll(statementTemplateFilter.filterItems(completionContext));
+        populateCompletionItemList(completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY), completionItems);
 
         return completionItems;
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/TopLevelResolver.java
@@ -17,7 +17,8 @@
 package org.ballerinalang.langserver.completions.resolvers;
 
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
@@ -38,31 +39,31 @@ import java.util.List;
 public class TopLevelResolver extends AbstractItemResolver {
 
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
-
-        ParserRuleContext parserRuleContext = dataModel.getParserRuleContext();
+        ParserRuleContext parserRuleContext = completionContext.get(DocumentServiceKeys.PARSER_RULE_CONTEXT_KEY);
         AbstractItemResolver errorContextResolver = parserRuleContext == null ? null :
                 CompletionItemResolver.getResolverByClass(parserRuleContext.getClass());
 
-        boolean noAt = findPreviousToken(dataModel, "@", 5) < 0;
+        boolean noAt = findPreviousToken(completionContext, "@", 5) < 0;
         if (noAt && (errorContextResolver == null || errorContextResolver == this)) {
             addTopLevelItems(completionItems);
         }
         if (errorContextResolver instanceof PackageNameContextResolver) {
-            completionItems.addAll(errorContextResolver.resolveItems(dataModel));
+            completionItems.addAll(errorContextResolver.resolveItems(completionContext));
         } else if (errorContextResolver instanceof ParserRuleConstantDefinitionContextResolver) {
-            completionItems.addAll(errorContextResolver.resolveItems(dataModel));
+            completionItems.addAll(errorContextResolver.resolveItems(completionContext));
         } else if (errorContextResolver instanceof ParserRuleGlobalVariableDefinitionContextResolver) {
             addTopLevelItems(completionItems);
-            completionItems.addAll(errorContextResolver.resolveItems(dataModel));
+            completionItems.addAll(errorContextResolver.resolveItems(completionContext));
         } else if (errorContextResolver instanceof ParserRuleTypeNameContextResolver) {
             addTopLevelItems(completionItems);
-            completionItems.addAll(errorContextResolver.resolveItems(dataModel));
+            completionItems.addAll(errorContextResolver.resolveItems(completionContext));
         } else {
             completionItems.addAll(
-                    CompletionItemResolver.getResolverByClass(AnnotationAttachment.class).resolveItems(dataModel)
+                    CompletionItemResolver
+                            .getResolverByClass(AnnotationAttachment.class).resolveItems(completionContext)
             );
         }
         return completionItems;

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/VariableDefinitionStatementContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/VariableDefinitionStatementContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.util.filters.BTypeFilter;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -28,11 +28,12 @@ import java.util.ArrayList;
  */
 class VariableDefinitionStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    @SuppressWarnings("unchecked")
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         BTypeFilter bTypeFilter = new BTypeFilter();
-        populateCompletionItemList(bTypeFilter.filterItems(dataModel), completionItems);
+        populateCompletionItemList(bTypeFilter.filterItems(completionContext), completionItems);
 
         return completionItems;
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAnnotationBodyContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAnnotationBodyContextResolver.java
@@ -18,7 +18,8 @@
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
 import org.antlr.v4.runtime.TokenStream;
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
@@ -33,15 +34,15 @@ public class ParserRuleAnnotationBodyContextResolver extends AbstractItemResolve
 
     /**
      * here we provide the attach keyword completion item.
-     * @param dataModel suggestions filter data model
+     * @param completionContext completion operation context
      * @return {@link ArrayList}
      */
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
-        TokenStream tokenStream = dataModel.getTokenStream();
-        int tokenIndex = dataModel.getTokenIndex();
+        TokenStream tokenStream = completionContext.get(DocumentServiceKeys.TOKEN_STREAM_KEY);
+        int tokenIndex = completionContext.get(DocumentServiceKeys.TOKEN_INDEX_KEY);
         int searchIndex = tokenIndex - 1;
 
         while (true) {

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAssignmentStatementContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAssignmentStatementContextResolver.java
@@ -15,10 +15,9 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
-
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
@@ -31,14 +30,15 @@ import java.util.ArrayList;
  */
 public class ParserRuleAssignmentStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         // TODO: left hand side of the assignment statement should analyze when suggesting the completions
         // TODO: at the moment we are using the same completion resolving criteria as the variable definition
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         Class parserRuleContext = BallerinaParser.VariableDefinitionStatementContext.class;
-        completionItems.addAll(CompletionItemResolver.getResolverByClass(parserRuleContext).resolveItems(dataModel));
+        completionItems.addAll(
+                CompletionItemResolver.getResolverByClass(parserRuleContext).resolveItems(completionContext));
 
         return completionItems;
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAttachmentPointContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleAttachmentPointContextResolver.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
@@ -30,7 +30,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleAttachmentPointContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         completionItems.add(populateCompletionItem(ItemResolverConstants.ACTION,
                 ItemResolverConstants.KEYWORD_TYPE, Priority.PRIORITY7.name(), ItemResolverConstants.ACTION));

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleConstantDefinitionContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleConstantDefinitionContextResolver.java
@@ -18,8 +18,9 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.PossibleToken;
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
@@ -33,11 +34,11 @@ import java.util.List;
  */
 public class ParserRuleConstantDefinitionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
-        List<PossibleToken> possibleTokenList = dataModel.getPossibleTokens();
+        List<PossibleToken> possibleTokenList = completionContext.get(DocumentServiceKeys.POSSIBLE_TOKENS_KEY);
 
         possibleTokenList.forEach(possibleToken -> {
             if (possibleToken.getTokenName().matches(".*[a-z].*")) {

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleExpressionVariableDefStatementContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleExpressionVariableDefStatementContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
@@ -32,10 +32,10 @@ import java.util.ArrayList;
  */
 public class ParserRuleExpressionVariableDefStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         // Here we are using the existing variable statement itm resolver
         Class parserRuleContextResolver = BallerinaParser.VariableDefinitionStatementContext.class;
-        return CompletionItemResolver.getResolverByClass(parserRuleContextResolver).resolveItems(dataModel);
+        return CompletionItemResolver.getResolverByClass(parserRuleContextResolver).resolveItems(completionContext);
     }
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleGlobalVariableDefinitionContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleGlobalVariableDefinitionContextResolver.java
@@ -18,7 +18,7 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleGlobalVariableDefinitionContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
         // currently we are returning a empty List
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         return completionItems;

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleStatementContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleStatementContextResolver.java
@@ -15,10 +15,11 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
-
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
@@ -37,19 +38,20 @@ import java.util.HashMap;
  */
 public class ParserRuleStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    @SuppressWarnings("unchecked")
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         HashMap<String, String> prioritiesMap = new HashMap<>();
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         // Here we specifically need to check whether the statement is function invocation,
         // action invocation or worker invocation
-        if (isActionOrFunctionInvocationStatement(dataModel)) {
+        if (isActionOrFunctionInvocationStatement(completionContext)) {
             PackageActionAndFunctionFilter actionAndFunctionFilter = new PackageActionAndFunctionFilter();
 
             // Get the action and function list
             ArrayList<SymbolInfo> actionFunctionList = new ArrayList<>();
-            actionFunctionList.addAll(actionAndFunctionFilter.filterItems(dataModel));
+            actionFunctionList.addAll(actionAndFunctionFilter.filterItems(completionContext));
 
             // Populate the completion items
             this.populateCompletionItemList(actionFunctionList, completionItems);
@@ -61,11 +63,11 @@ public class ParserRuleStatementContextResolver extends AbstractItemResolver {
 
             return completionItems;
         } else {
-            populateCompletionItemList(dataModel.getVisibleSymbols(), completionItems);
+            populateCompletionItemList(completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY), completionItems);
             StatementTemplateFilter statementTemplateFilter = new StatementTemplateFilter();
             // Add the statement templates
-            completionItems.addAll(statementTemplateFilter.filterItems(dataModel));
-            this.populateBasicTypes(completionItems, dataModel.getSymbolTable());
+            completionItems.addAll(statementTemplateFilter.filterItems(completionContext));
+            this.populateBasicTypes(completionItems, completionContext.get(DocumentServiceKeys.SYMBOL_TABLE_KEY));
 
             CompletionItem xmlns = new CompletionItem();
             xmlns.setLabel(ItemResolverConstants.XMLNS);

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTransformStatementBodyContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTransformStatementBodyContextResolver.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
@@ -38,14 +39,14 @@ import java.util.stream.Collectors;
  */
 public class ParserRuleTransformStatementBodyContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         BTypeFilter bTypeFilter = new BTypeFilter();
-        populateCompletionItemList(bTypeFilter.filterItems(dataModel), completionItems);
+        populateCompletionItemList(bTypeFilter.filterItems(completionContext), completionItems);
 
-        List<SymbolInfo> variableDefs =  dataModel.getVisibleSymbols().stream()
+        List<SymbolInfo> variableDefs =  completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY).stream()
                 .filter(symbolInfo -> symbolInfo.getSymbol() instanceof SimpleVariableDef)
                 .collect(Collectors.toList());
         populateCompletionItemList(variableDefs, completionItems);

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTriggerWorkerContext.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTriggerWorkerContext.java
@@ -15,10 +15,9 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
-
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.eclipse.lsp4j.CompletionItem;
 
@@ -29,7 +28,7 @@ import java.util.ArrayList;
  */
 public class ParserRuleTriggerWorkerContext extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         return new ArrayList<>();
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTypeNameContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleTypeNameContextResolver.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.resolvers.AbstractItemResolver;
 import org.ballerinalang.langserver.completions.util.filters.StatementTemplateFilter;
 import org.eclipse.lsp4j.CompletionItem;
@@ -30,13 +31,14 @@ import java.util.ArrayList;
  */
 public class ParserRuleTypeNameContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    @SuppressWarnings("unchecked")
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
         StatementTemplateFilter statementTemplateFilter = new StatementTemplateFilter();
         // Add the statement templates
-        completionItems.addAll(statementTemplateFilter.filterItems(dataModel));
-        this.populateBasicTypes(completionItems, dataModel.getSymbolTable());
+        completionItems.addAll(statementTemplateFilter.filterItems(completionContext));
+        this.populateBasicTypes(completionItems, completionContext.get(DocumentServiceKeys.SYMBOL_TABLE_KEY));
         return completionItems;
     }
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleVariableDefinitionStatementContextResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/resolvers/parsercontext/ParserRuleVariableDefinitionStatementContextResolver.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langserver.completions.resolvers.parsercontext;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
@@ -37,14 +38,15 @@ import java.util.stream.Collectors;
  */
 public class ParserRuleVariableDefinitionStatementContextResolver extends AbstractItemResolver {
     @Override
-    public ArrayList<CompletionItem> resolveItems(SuggestionsFilterDataModel dataModel) {
+    @SuppressWarnings("unchecked")
+    public ArrayList<CompletionItem> resolveItems(TextDocumentServiceContext completionContext) {
 
         // Here we specifically need to check whether the statement is function invocation,
         // action invocation or worker invocation
-        if (isActionOrFunctionInvocationStatement(dataModel)) {
+        if (isActionOrFunctionInvocationStatement(completionContext)) {
             PackageActionAndFunctionFilter actionAndFunctionFilter = new PackageActionAndFunctionFilter();
             ArrayList<SymbolInfo> actionAndFunctions = new ArrayList<>();
-            actionAndFunctions.addAll(actionAndFunctionFilter.filterItems(dataModel));
+            actionAndFunctions.addAll(actionAndFunctionFilter.filterItems(completionContext));
             ArrayList<CompletionItem> completionItems = new ArrayList<>();
             this.populateCompletionItemList(actionAndFunctions, completionItems);
             return completionItems;
@@ -57,7 +59,7 @@ public class ParserRuleVariableDefinitionStatementContextResolver extends Abstra
             createKeyword.setSortText(Priority.PRIORITY7.name());
 
             ArrayList<CompletionItem> completionItems = new ArrayList<>();
-            List<SymbolInfo> filteredList = dataModel.getVisibleSymbols()
+            List<SymbolInfo> filteredList = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY)
                     .stream()
                     .filter(symbolInfo -> !((symbolInfo.getScopeEntry().symbol instanceof BTypeSymbol)
                                     && !(symbolInfo.getScopeEntry().symbol instanceof BPackageSymbol)))

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/BTypeFilter.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/BTypeFilter.java
@@ -17,7 +17,8 @@
 */
 package org.ballerinalang.langserver.completions.util.filters;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
+import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.SymbolInfo;
 import org.ballerinalang.model.types.BType;
 
@@ -28,9 +29,9 @@ import java.util.stream.Collectors;
  * Filter the BTypes.
  */
 public class BTypeFilter implements SymbolFilter {
-    public List<SymbolInfo> filterItems(SuggestionsFilterDataModel dataModel) {
+    public List<SymbolInfo> filterItems(TextDocumentServiceContext completionContext) {
         List<SymbolInfo> filteredList;
-        filteredList = dataModel.getVisibleSymbols()
+        filteredList = completionContext.get(CompletionKeys.VISIBLE_SYMBOLS_KEY)
                 .stream()
                 .filter(symbolInfo -> symbolInfo.getSymbol() instanceof BType)
                 .collect(Collectors.toList());

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/StatementTemplateFilter.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/StatementTemplateFilter.java
@@ -15,10 +15,9 @@
 *  specific language governing permissions and limitations
 *  under the License.
 */
-
 package org.ballerinalang.langserver.completions.util.filters;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.consts.ItemResolverConstants;
 import org.ballerinalang.langserver.completions.consts.Priority;
 import org.ballerinalang.langserver.completions.consts.Snippet;
@@ -33,7 +32,7 @@ import java.util.List;
  */
 public class StatementTemplateFilter implements SymbolFilter {
     @Override
-    public List filterItems(SuggestionsFilterDataModel dataModel) {
+    public List filterItems(TextDocumentServiceContext completionContext) {
         ArrayList<CompletionItem> completionItems = new ArrayList<>();
 
         // Populate the statement templates

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/SymbolFilter.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/filters/SymbolFilter.java
@@ -17,7 +17,7 @@
 */
 package org.ballerinalang.langserver.completions.util.filters;
 
-import org.ballerinalang.langserver.completions.SuggestionsFilterDataModel;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +28,8 @@ import java.util.List;
 public interface SymbolFilter {
     /**
      * Filters the symbolInfo from the list based on a particular filter criteria.
-     * @param dataModel - Suggestion filter data model
+     * @param completionContext - Completion operation context
      * @return {@link ArrayList}
      */
-    List filterItems(SuggestionsFilterDataModel dataModel);
+    List filterItems(TextDocumentServiceContext completionContext);
 }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/BlockStatementScopeResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/BlockStatementScopeResolver.java
@@ -16,6 +16,8 @@
 
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
@@ -45,9 +47,10 @@ public class BlockStatementScopeResolver extends CursorPositionResolver {
      * @return true|false
      */
     @Override
-    public boolean isCursorBeforeStatement(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor) {
-        int line = treeVisitor.getTextDocumentPositionParams().getPosition().getLine();
-        int col = treeVisitor.getTextDocumentPositionParams().getPosition().getCharacter();
+    public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
+                                      TextDocumentServiceContext completionContext) {
+        int line = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition().getLine();
+        int col = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition().getCharacter();
         DiagnosticPos zeroBasedPos = this.toZeroBasedPosition(nodePosition);
         int nodeSLine = zeroBasedPos.sLine;
         int nodeSCol = zeroBasedPos.sCol;

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/CursorPositionResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/CursorPositionResolver.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -24,14 +24,24 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
  * Cursor position resolver interface.
  */
 public abstract class CursorPositionResolver {
-    public abstract boolean isCursorBeforeStatement(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor);
+
+    /**
+     * Check whether the cursor is positioned before the given node start.
+     * @param nodePosition          Position of the node
+     * @param node                  Node
+     * @param treeVisitor           {@link TreeVisitor} current tree visitor instance
+     * @param completionContext     Completion operation context
+     * @return {@link Boolean}      Whether the cursor is before the node start or not
+     */
+    public abstract boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
+                                               TextDocumentServiceContext completionContext);
 
     /**
      * Convert the diagnostic position to a zero based positioning diagnostic position.
      * @param diagnosticPos - diagnostic position to be cloned
      * @return {@link DiagnosticPos} converted diagnostic position
      */
-    public DiagnosticPos  toZeroBasedPosition(DiagnosticPos diagnosticPos) {
+    DiagnosticPos  toZeroBasedPosition(DiagnosticPos diagnosticPos) {
         int startLine = diagnosticPos.getStartLine() - 1;
         int endLine = diagnosticPos.getEndLine() - 1;
         int startColumn = diagnosticPos.getStartColumn() - 1;

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/PackageNodeScopeResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/PackageNodeScopeResolver.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -25,7 +26,8 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
  */
 public class PackageNodeScopeResolver extends CursorPositionResolver {
     @Override
-    public boolean isCursorBeforeStatement(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor) {
+    public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
+                                      TextDocumentServiceContext completionContext) {
         // TODO: Finalize the implementation
         return false;
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ResourceParamScopeResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ResourceParamScopeResolver.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -31,7 +32,8 @@ public class ResourceParamScopeResolver extends CursorPositionResolver {
      * @return true|false
      */
     @Override
-    public boolean isCursorBeforeStatement(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor) {
+    public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
+                                      TextDocumentServiceContext completionContext) {
         // TODO: Finalize the implementation
         return false;
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ServiceScopeResolver.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/positioning/resolvers/ServiceScopeResolver.java
@@ -15,8 +15,11 @@
  */
 package org.ballerinalang.langserver.completions.util.positioning.resolvers;
 
+import org.ballerinalang.langserver.DocumentServiceKeys;
+import org.ballerinalang.langserver.TextDocumentServiceContext;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.model.tree.Node;
+import org.eclipse.lsp4j.Position;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -28,9 +31,11 @@ import java.util.Map;
  */
 public class ServiceScopeResolver extends CursorPositionResolver {
     @Override
-    public boolean isCursorBeforeStatement(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor) {
-        int line = treeVisitor.getTextDocumentPositionParams().getPosition().getLine();
-        int col = treeVisitor.getTextDocumentPositionParams().getPosition().getCharacter();
+    public boolean isCursorBeforeNode(DiagnosticPos nodePosition, Node node, TreeVisitor treeVisitor,
+                                      TextDocumentServiceContext completionContext) {
+        Position position = completionContext.get(DocumentServiceKeys.POSITION_KEY).getPosition();
+        int line = position.getLine();
+        int col = position.getCharacter();
         DiagnosticPos zeroBasedPo = this.toZeroBasedPosition(nodePosition);
         int nodeSLine = zeroBasedPo.sLine;
         int nodeSCol = zeroBasedPo.sCol;

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionDataHolder.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/definition/DefinitionDataHolder.java
@@ -1,0 +1,26 @@
+package org.ballerinalang.langserver.definition;
+
+import org.eclipse.lsp4j.Position;
+
+/**
+ * Holds the Meta data to generate the Definition Item.
+ */
+public class DefinitionDataHolder {
+
+    private String compilationUnitName;
+
+    private Position position;
+
+    public DefinitionDataHolder(String compilationUnitName, Position position) {
+        this.compilationUnitName = compilationUnitName;
+        this.position = position;
+    }
+
+    public String getCompilationUnitName() {
+        return compilationUnitName;
+    }
+
+    public Position getPosition() {
+        return position;
+    }
+}

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -83,7 +83,7 @@ public class SignatureHelpUtil {
      * @param context                   Signature help package context
      * @return {@link SignatureHelp}    Signature help for the completion
      */
-    public static SignatureHelp getFunctionSignatureHelp(String functionName, SignatureHelpPackageContext context) {
+    public static SignatureHelp getFunctionSignatureHelp(String functionName, BLangPackageWrapper context) {
         // Get the functions List
         List<BLangFunction> functions = context.getItems(BLangFunction.class);
 
@@ -243,13 +243,13 @@ public class SignatureHelpUtil {
     /**
      * Package context to keep the builtin and the current package.
      */
-    public static class SignatureHelpPackageContext {
+    public static class BLangPackageWrapper {
 
         BLangPackage builtin;
 
         BLangPackage current;
 
-        public SignatureHelpPackageContext(BLangPackage builtin, BLangPackage current) {
+        public BLangPackageWrapper(BLangPackage builtin, BLangPackage current) {
             this.builtin = builtin;
             this.current = current;
         }


### PR DESCRIPTION
## Purpose
> Resolves #45 

## Goals
> In order to avoid the complexity faced with the suggestions filter data model, as well as the lack of clean approach to differentiate the operation based properties handling, we introduce a new way of handling those properties gracefully via Contexts. For each of the operation such as completion, signature help, hover, and etc we can use a context object to be passed through the entire operation lifecycle. 