### PR TITLE
Added markdown support for hover content

### DIFF
--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverTreeVisitor.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverTreeVisitor.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
 
 /**
  * Tree visitor for the hover functionality.
- * */
+ */
 public class HoverTreeVisitor extends BLangNodeVisitor {
 
     private String fileName;


### PR DESCRIPTION
## Purpose
This will add the markdown support for hover provider which will help style the hover information and improve the readability of the hover content. 

![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/9109762/34016682-d2fd5fbc-e148-11e7-8f1a-87aef41f59ea.gif)

## Approach
From the hover provider implementation content will be formatted using markdowns which enable IDE to show more style enriched information improve user's readability.
