### PR TITLE
Added support for Struct and Enum.

### DIFF
--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -19,8 +19,6 @@ import org.ballerinalang.langserver.completions.CompletionKeys;
 import org.ballerinalang.langserver.completions.TreeVisitor;
 import org.ballerinalang.langserver.completions.consts.CompletionItemResolver;
 import org.ballerinalang.langserver.completions.resolvers.TopLevelResolver;
-import org.ballerinalang.langserver.hover.HoverKeys;
-import org.ballerinalang.langserver.hover.HoverTreeVisitor;
 import org.ballerinalang.langserver.hover.util.HoverUtil;
 import org.ballerinalang.langserver.signature.SignatureHelpUtil;
 import org.ballerinalang.langserver.symbols.SymbolFindingVisitor;
@@ -133,25 +131,10 @@ public class BallerinaTextDocumentService implements TextDocumentService {
     public CompletableFuture<Hover> hover(TextDocumentPositionParams position) {
         return CompletableFuture.supplyAsync(() -> {
             TextDocumentServiceContext hoverContext = new TextDocumentServiceContext();
-            HoverUtil hoverUtil = new HoverUtil();
             hoverContext.put(DocumentServiceKeys.FILE_URI_KEY, position.getTextDocument().getUri());
             hoverContext.put(DocumentServiceKeys.POSITION_KEY, position);
             BLangPackage currentBLangPackage = TextDocumentServiceUtil.getBLangPackage(hoverContext, documentManager);
-            HoverTreeVisitor hoverTreeVisitor = new HoverTreeVisitor(hoverContext);
-            currentBLangPackage.accept(hoverTreeVisitor);
-            Hover hover;
-            // If the cursor is on a node of the current package go inside, else check builtin and native packages.
-            if (hoverContext.get(HoverKeys.PACKAGE_OF_HOVER_NODE_KEY) != null
-                    && hoverContext.get(HoverKeys.PACKAGE_OF_HOVER_NODE_KEY).name.getValue()
-                    .equals(currentBLangPackage.symbol.getName().getValue())) {
-                hover = hoverUtil.getHoverInformation(currentBLangPackage, hoverContext);
-            } else {
-                BLangPackage packages = hoverUtil
-                        .getPackageByName(hoverContext.get(DocumentServiceKeys.COMPILER_CONTEXT_KEY),
-                                hoverContext.get(HoverKeys.PACKAGE_OF_HOVER_NODE_KEY).name);
-                hover = hoverUtil.getHoverInformation(packages, hoverContext);
-            }
-            return hover;
+            return HoverUtil.getHoverContent(hoverContext, currentBLangPackage);
         });
     }
 

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverTreeVisitor.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverTreeVisitor.java
@@ -59,6 +59,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWhile;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerReceive;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangWorkerSend;
+import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -126,6 +127,19 @@ public class HoverTreeVisitor extends BLangNodeVisitor {
     }
 
     public void visit(BLangStruct structNode) {
+        if (HoverUtil.isMatchingPosition(structNode.getPosition(), this.position)) {
+            this.context.put(HoverKeys.HOVERING_OVER_NODE_KEY, structNode);
+            this.context.put(HoverKeys.PREVIOUSLY_VISITED_NODE_KEY, this.previousNode);
+            this.context.put(HoverKeys.NAME_OF_HOVER_NODE_KEY, structNode.name);
+            this.context.put(HoverKeys.PACKAGE_OF_HOVER_NODE_KEY, structNode.symbol.pkgID);
+            this.context.put(HoverKeys.SYMBOL_KIND_OF_HOVER_NODE_KEY, structNode.symbol.kind);
+        } else {
+            structNode.fields.forEach(e -> this.acceptNode(e));
+        }
+    }
+
+    @Override
+    public void visit(BLangUserDefinedType userDefinedType) {
         // TODO: implement support for hover.
     }
 
@@ -136,6 +150,9 @@ public class HoverTreeVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangVariable varNode) {
+        if (varNode.expr != null) {
+            this.acceptNode(varNode.expr);
+        }
     }
 
     @Override
@@ -160,7 +177,9 @@ public class HoverTreeVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangVariableDef varDefNode) {
-        // TODO: implement support for hover.
+        if (varDefNode.getVariable() != null) {
+            this.acceptNode(varDefNode.getVariable());
+        }
     }
 
     @Override
@@ -264,6 +283,7 @@ public class HoverTreeVisitor extends BLangNodeVisitor {
             this.context.put(HoverKeys.NAME_OF_HOVER_NODE_KEY, invocationExpr.name);
             this.context.put(HoverKeys.PACKAGE_OF_HOVER_NODE_KEY, invocationExpr.symbol.pkgID);
             this.context.put(HoverKeys.SYMBOL_KIND_OF_HOVER_NODE_KEY, invocationExpr.symbol.kind);
+            this.terminateVisitor = true;
         }
     }
 

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/constants/HoverConstants.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/constants/HoverConstants.java
@@ -2,12 +2,14 @@ package org.ballerinalang.langserver.hover.constants;
 
 /**
  * Constants for hover functionality.
- * */
+ */
 public class HoverConstants {
     public static final String FUNCTION = "FUNCTION";
+    public static final String STRUCT = "STRUCT";
     public static final String ACTION = "ACTION";
+    public static final String ENUM = "ENUM";
     public static final String DESCRIPTION = "Description";
     public static final String PARAM = "Param";
     public static final String RETURN = "Return";
-    public static final String BUILT_IN_PACKAGE = "ballerina.builtin";
+    public static final String FIELD = "Field";
 }


### PR DESCRIPTION
## Purpose
This is to add the hover support for Struct and Enum from the language server side.  

## Goals
Struct hover support will be as below.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/9109762/34205568-ea6ee4a4-e5a8-11e7-8e9c-37596289a714.gif)

Enum hover support will be as below.

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/9109762/34205720-85b51ee2-e5a9-11e7-82a7-0114bec9c9a6.gif)

## Related Issues
https://github.com/ballerinalang/language-server/issues/62