### PR TITLE
Capture exceptions in runtime

### DIFF
--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -53,7 +53,6 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
         res.getCapabilities().setCompletionProvider(new CompletionOptions());
         res.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
         res.getCapabilities().setSignatureHelpProvider(signatureHelpOptions);
-        res.getCapabilities().setDefinitionProvider(true);
         res.getCapabilities().setHoverProvider(true);
         res.getCapabilities().setDocumentSymbolProvider(true);
 

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -197,20 +197,16 @@ public class BallerinaTextDocumentService implements TextDocumentService {
         symbolsContext.put(DocumentServiceKeys.FILE_URI_KEY, uri);
         symbolsContext.put(DocumentServiceKeys.SYMBOL_LIST_KEY, symbols);
 
-        try {
-            BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(symbolsContext, documentManager);
+        BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(symbolsContext, documentManager);
 
-            Optional<BLangCompilationUnit> documentCUnit = bLangPackage.getCompilationUnits().stream()
-                    .filter(cUnit -> (uri.endsWith(cUnit.getName())))
-                    .findFirst();
+        Optional<BLangCompilationUnit> documentCUnit = bLangPackage.getCompilationUnits().stream()
+                .filter(cUnit -> (uri.endsWith(cUnit.getName())))
+                .findFirst();
 
-            documentCUnit.ifPresent(cUnit -> {
-                SymbolFindingVisitor visitor = new SymbolFindingVisitor(symbolsContext);
-                cUnit.accept(visitor);
-            });
-        } catch (Exception e) {
-            // Do nothing
-        }
+        documentCUnit.ifPresent(cUnit -> {
+            SymbolFindingVisitor visitor = new SymbolFindingVisitor(symbolsContext);
+            cUnit.accept(visitor);
+        });
 
         return CompletableFuture.supplyAsync(() -> symbols);
     }

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -59,8 +59,6 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wso2.ballerinalang.compiler.Compiler;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
@@ -88,7 +86,6 @@ public class BallerinaTextDocumentService implements TextDocumentService {
 
     private final BallerinaLanguageServer ballerinaLanguageServer;
     private final WorkspaceDocumentManager documentManager;
-    private static final Logger LOGGER = LoggerFactory.getLogger(BallerinaTextDocumentService.class);
     private Map<String, List<Diagnostic>> lastDiagnosticMap;
     private BLangPackageContext bLangPackageContext;
 
@@ -163,9 +160,15 @@ public class BallerinaTextDocumentService implements TextDocumentService {
             SignatureHelpUtil.captureCallableItemInfo(position.getPosition(), fileContent, signatureContext);
             signatureContext.put(DocumentServiceKeys.POSITION_KEY, position);
             signatureContext.put(DocumentServiceKeys.FILE_URI_KEY, uri);
-            BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(signatureContext, documentManager);
-            bLangPackageContext.addPackage(bLangPackage);
-            return SignatureHelpUtil.getFunctionSignatureHelp(signatureContext, bLangPackageContext);
+            SignatureHelp signatureHelp;
+            try {
+                BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(signatureContext, documentManager);
+                bLangPackageContext.addPackage(bLangPackage);
+                signatureHelp = SignatureHelpUtil.getFunctionSignatureHelp(signatureContext, bLangPackageContext);
+            } catch (Exception e) {
+                signatureHelp = new SignatureHelp();
+            }
+            return signatureHelp;
         });
     }
 
@@ -194,16 +197,20 @@ public class BallerinaTextDocumentService implements TextDocumentService {
         symbolsContext.put(DocumentServiceKeys.FILE_URI_KEY, uri);
         symbolsContext.put(DocumentServiceKeys.SYMBOL_LIST_KEY, symbols);
 
-        BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(symbolsContext, documentManager);
+        try {
+            BLangPackage bLangPackage = TextDocumentServiceUtil.getBLangPackage(symbolsContext, documentManager);
 
-        Optional<BLangCompilationUnit> documentCUnit = bLangPackage.getCompilationUnits().stream()
-                .filter(cUnit -> (uri.endsWith(cUnit.getName())))
-                .findFirst();
+            Optional<BLangCompilationUnit> documentCUnit = bLangPackage.getCompilationUnits().stream()
+                    .filter(cUnit -> (uri.endsWith(cUnit.getName())))
+                    .findFirst();
 
-        documentCUnit.ifPresent(cUnit -> {
-            SymbolFindingVisitor visitor = new SymbolFindingVisitor(symbolsContext);
-            cUnit.accept(visitor);
-        });
+            documentCUnit.ifPresent(cUnit -> {
+                SymbolFindingVisitor visitor = new SymbolFindingVisitor(symbolsContext);
+                cUnit.accept(visitor);
+            });
+        } catch (Exception e) {
+            // Do nothing
+        }
 
         return CompletableFuture.supplyAsync(() -> symbols);
     }
@@ -302,7 +309,7 @@ public class BallerinaTextDocumentService implements TextDocumentService {
     }
 
     private void publishDiagnostics(List<org.ballerinalang.util.diagnostic.Diagnostic> balDiagnostics, Path path) {
-        Map<String, List<Diagnostic>> diagnosticsMap = new HashMap<String, List<Diagnostic>>();
+        Map<String, List<Diagnostic>> diagnosticsMap = new HashMap<>();
         balDiagnostics.forEach(diagnostic -> {
             Diagnostic d = new Diagnostic();
             d.setSeverity(DiagnosticSeverity.Error);
@@ -380,9 +387,9 @@ public class BallerinaTextDocumentService implements TextDocumentService {
         try {
             path = Paths.get(new URL(uri).toURI());
         } catch (URISyntaxException | MalformedURLException e) {
-            LOGGER.error(e.getMessage());
-        } finally {
-            return path;
+            // Do Nothing
         }
+        
+        return path;
     }
 }


### PR DESCRIPTION
## Purpose
> When runtime exceptions are thrown and these are directly exposed through the launchers (stdout), IDEs shows them in the console in a disturbing manner. Therefore we need to capture them.

## Goals
> Capture the exceptions whenever there is and gracefully handle them at the TextDocumentService