### PR TITLE
Create a jar without including dependencies from ballerina.org

### DIFF
--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/DocumentServiceKeys.java
@@ -29,7 +29,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import java.util.List;
 
 /**
- * Text Document Service context keys for the completion operation context
+ * Text Document Service context keys for the completion operation context.
  * @since 0.95.5
  */
 public class DocumentServiceKeys {

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
@@ -128,7 +128,7 @@ public class TextDocumentServiceUtil {
         Path filePath = getPath(uri);
         Path fileNamePath = filePath.getFileName();
         String fileName = "";
-        if(fileNamePath != null) {
+        if (fileNamePath != null) {
             fileName = fileNamePath.toString();
         }
 

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/TextDocumentServiceUtil.java
@@ -126,8 +126,12 @@ public class TextDocumentServiceUtil {
         String uri = context.get(DocumentServiceKeys.FILE_URI_KEY);
         String fileContent = docManager.getFileContent(Paths.get(URI.create(uri)));
         Path filePath = getPath(uri);
-        String[] pathComponents = uri.split("\\" + File.separator);
-        String fileName = pathComponents[pathComponents.length - 1];
+        Path fileNamePath = filePath.getFileName();
+        String fileName = "";
+        if(fileNamePath != null) {
+            fileName = fileNamePath.toString();
+        }
+
         String pkgName = TextDocumentServiceUtil.getPackageFromContent(fileContent);
         String sourceRoot = TextDocumentServiceUtil.getSourceRoot(filePath, pkgName);
         PackageRepository packageRepository = new WorkspacePackageRepository(sourceRoot, docManager);

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionKeys.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/CompletionKeys.java
@@ -23,7 +23,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import java.util.List;
 
 /**
- * Text Document Service context keys for the completion operation context
+ * Text Document Service context keys for the completion operation context.
  * @since 0.95.5
  */
 public class CompletionKeys {

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureKeys.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureKeys.java
@@ -20,7 +20,7 @@ package org.ballerinalang.langserver.signature;
 import org.ballerinalang.langserver.LanguageServerContext;
 
 /**
- * Text Document Service context keys for the signature help operation context
+ * Text Document Service context keys for the signature help operation context.
  * @since 0.95.6
  */
 public class SignatureKeys {

--- a/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/util/CompletionTestUtil.java
+++ b/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/util/CompletionTestUtil.java
@@ -110,7 +110,7 @@ public class CompletionTestUtil {
     }
 
     /**
-     * Get the completions list
+     * Get the completions list.
      * @param documentManager   Document manager instance
      * @param pos               {@link TextDocumentPositionParams} position params
      */
@@ -138,7 +138,7 @@ public class CompletionTestUtil {
     }
 
     /**
-     * Prepare the Document manager instance with the given file and issue the did open operation
+     * Prepare the Document manager instance with the given file and issue the did open operation.
      * @param uri           File Uri
      * @param balContent    File Content
      * @return  {@link WorkspaceDocumentManagerImpl}

--- a/modules/langserver-core/src/test/java/org/ballerinalang/langserver/hover/HoverProviderTest.java
+++ b/modules/langserver-core/src/test/java/org/ballerinalang/langserver/hover/HoverProviderTest.java
@@ -27,6 +27,9 @@ import java.util.concurrent.ExecutionException;
 
 import static java.lang.Thread.sleep;
 
+/**
+ * Tests hover feature.
+ */
 public class HoverProviderTest {
     private static final String TESTS_SAMPLES = "src" + File.separator + "test" + File.separator + "resources"
             + File.separator + "hover";

--- a/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpUtilTest.java
+++ b/modules/langserver-core/src/test/java/org/ballerinalang/langserver/signature/SignatureHelpUtilTest.java
@@ -29,7 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /**
- * Test Case to verify the Signature help utility functions
+ * Test Case to verify the Signature help utility functions.
  */
 public class SignatureHelpUtilTest {
     private static final ClassLoader CLASS_LOADER = SignatureHelpUtilTest.class.getClassLoader();

--- a/modules/launchers/stdio-launcher/pom.xml
+++ b/modules/launchers/stdio-launcher/pom.xml
@@ -21,34 +21,45 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                <archive>
-                    <manifest>
-                    <mainClass>org.ballerinalang.langserver.launchers.stdio.Main</mainClass>
-                    </manifest>
-                </archive>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-                <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                <execution>
-                    <id>make-assembly</id>
-                    <phase>package</phase>
-                    <goals>
-                    <goal>single</goal>
-                    </goals>
-                </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${maven.shadeplugin.version}</version>
                 <executions>
                     <execution>
+                        <id>including-non-ballerina-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.ballerinalang:*</artifact>
+                                    <includes>
+                                        org/ballerinalang/langserver/**
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.ballerinalang.langserver.launchers.stdio.Main</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-non-ballerina-dependencies</shadedClassifierName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>including-dependencies</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
@@ -70,19 +81,8 @@
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>com.github.jknack:handlebars</exclude>
-                                    <exclude>org.wso2.orbit.org.antlr:antlr4-runtime</exclude>
-                                    <exclude>org.apache.ws.commons.axiom:axiom-dom</exclude>
-                                    <exclude>org.wso2.staxon:staxon-core</exclude>
-                                    <exclude>commons-pool.wso2:commons-pool</exclude>
-                                    <exclude>org.wso2.carbon.utils:carbon-utils</exclude>
-                                    <exclude>org.wso2.orbit.org.yaml:snakeyaml</exclude>
-                                    <exclude>org.yaml:snakeyaml</exclude>
-                                    <exclude>org.atomikos.wso2:atomikos</exclude>
-                                </excludes>
-                            </artifactSet>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Purpose
* Create an uber jar without ballerina.org dependencies stdio launcher

In addition to the jar with all dependencies included, another jar is created without dependencies from ballerina.org group. These dependencies are included in the ballerina distribution.

The new jar is used when the language client has specified the location of the ballerina sdk. So these dependencies are resolved using the jars inside `<sdk-location>/bre/lib`

This allows language server to compile source code that uses ballerina libraries not in the standard distribution but added later. (for example some connectors like the mongodb connector)

* Fixes file path for windows. This fixes hover and completions not working for windows.
