### PR TITLE
Added  shutdown and exit implementation for the language server

### DIFF
--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -37,7 +37,7 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
     private LanguageClient client = null;
     private TextDocumentService textService;
     private WorkspaceService workspaceService;
-    private boolean shutdown = false;
+    private int shutdown = 1;
 
     public BallerinaLanguageServer() {
         textService = new BallerinaTextDocumentService(this);
@@ -62,16 +62,12 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
     }
 
     public CompletableFuture<Object> shutdown() {
-        shutdown = true;
+        shutdown = 0;
         return CompletableFuture.supplyAsync(Object::new);
     }
 
     public void exit() {
-        if (shutdown) {
-            System.exit(0);
-        } else {
-            System.exit(1);
-        }
+        System.exit(shutdown);
     }
 
     public TextDocumentService getTextDocumentService() {

--- a/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +37,7 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
     private LanguageClient client = null;
     private TextDocumentService textService;
     private WorkspaceService workspaceService;
+    private boolean shutdown = false;
 
     public BallerinaLanguageServer() {
         textService = new BallerinaTextDocumentService(this);
@@ -61,12 +62,18 @@ public class BallerinaLanguageServer implements LanguageServer, LanguageClientAw
     }
 
     public CompletableFuture<Object> shutdown() {
-        return CompletableFuture.supplyAsync(() -> Boolean.TRUE);
+        shutdown = true;
+        return CompletableFuture.supplyAsync(Object::new);
     }
 
     public void exit() {
+        if (shutdown) {
+            System.exit(0);
+        } else {
+            System.exit(1);
+        }
     }
-    
+
     public TextDocumentService getTextDocumentService() {
         return this.textService;
     }


### PR DESCRIPTION
## Purpose
> When the IDE closed language server was still running as implementation of the LSP's shutdown and exit functionality haven't been implemented yet.

## Goal
> This PR will fix that issue by implementing the shutdown and exit functionality as to the LSP.